### PR TITLE
Better form handling

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    mxit-rails (0.2.9)
+    mxit-rails (0.3.0)
       rails (~> 3.2.3)
       sass-rails (~> 3.2.1)
 

--- a/app/helpers/mxit_rails_helper.rb
+++ b/app/helpers/mxit_rails_helper.rb
@@ -22,18 +22,6 @@ module MxitRailsHelper
     str.html_safe
   end
 
-  def mxit_link route, label, variables=nil
-    unless variables.nil?
-      var_strings = []
-      #TODO: Use default Rails get encoding
-      variables.each do |key, value|
-        var_strings << "#{key}=#{value}"
-      end
-      route += "?#{var_strings.join('&')}"
-    end
-    output = "<a href=\"#{route}\">#{label}</a>".html_safe
-  end
-
   def mxit_style *names
     content = []
     names.each do |name|
@@ -42,12 +30,34 @@ module MxitRailsHelper
     content.join(' ').html_safe
   end
 
-  def mxit_nav_link target, label
-    "#{ mxit_link target, label }<br /><br />".html_safe
-  end
-
   def mxit_proceed content
     "<br /><b style=\"#{ mxit_style :link }\"> &gt; #{content}</b><br />".html_safe
+  end
+
+  def mxit_select_row label, value, selected
+    @_mxit_select_index ||= 0
+    @_mxit_select_index += 1
+
+    target = "#{request.path}?"
+    if @_mxit.multi_select
+      # Which input to modify, and which key to toggle for that input
+      target += "_mxit_rails_multi_select=#{@_mxit.select}&_mxit_rails_multi_select_value=#{value}"
+    else
+      target += "_mxit_rails_submit=true&#{@_mxit.select}=#{value}"
+    end
+
+    content = selected ? "<b>#{label}</b>" : label
+
+    output = "<a href=\"#{target}\">"
+    if @_mxit.numbered_list
+      output += "#{@_mxit_select_index}</a>) #{content}"
+    else
+      output += "#{label}</a>"
+      output = (selected ? '+ ' : '- ') + output
+    end
+    output += "<br />"
+
+    output.html_safe
   end
 
 end

--- a/app/views/layouts/mxit.html.erb
+++ b/app/views/layouts/mxit.html.erb
@@ -33,16 +33,33 @@
 
   <br />
   <% if @_mxit.input %>
-    <%= mxit_proceed @_mxit.input_label %>
+    <% if @_mxit.input_label %>
+      <%= mxit_proceed @_mxit.input_label %>
+    <% end %>
 
   <% elsif @_mxit.select %>
-    <%= mxit_proceed @_mxit.select_label %>
-    <% @_mxit.select_options.each do |key, value| %>
-    - <%= mxit_link(request.path, value, {_mxit_rails_submit: 'Proceed', @_mxit.select => key}) %><br />
+    <% if @_mxit.multi_select %>
+      <% if @_mxit.select_label %>
+        <%= @_mxit.select_label %><br />
+      <% end %>
+
+      <% @_mxit.select_options.each do |value, label| %>
+        <%= mxit_select_row label, value, @_mxit.selected.include?(value) %>
+      <% end %>
+
+      <%= mxit_proceed link_to(@_mxit.multi_select_next, "#{request.path}?_mxit_rails_submit=true&_mxit_rails_multi_select=#{@_mxit.select}") %>
+
+    <% else %>
+      <% if @_mxit.select_label %>
+        <%= mxit_proceed @_mxit.select_label %>
+      <% end %>
+      <% @_mxit.select_options.each do |value, label| %>
+        <%= mxit_select_row label, value, @_mxit.selected.include?(value) %>
+      <% end %>
     <% end %>
 
   <% elsif @_mxit.proceed %>
-    <%= mxit_proceed mxit_link(request.path, @_mxit.proceed.to_s.capitalize, {_mxit_rails_submit: 'Proceed'}) %>
+    <%= mxit_proceed link_to(@_mxit.proceed.to_s.capitalize, "#{request.path}?_mxit_rails_submit=true}") %>
   <% end %>
 
 
@@ -56,7 +73,7 @@
     <!-- The form must be outside the table - put it right at the bottom of the page -->
     <form method="POST" action="<%= request.path %>">
         <input type="text" name="<%= @_mxit.input %>" />
-        <input type="submit" name="_mxit_rails_submit" value="Proceed" />
+        <input type="submit" name="_mxit_rails_submit" value="true" />
     </form>
   <% end %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
 
-  if Rails.env.development?
+  unless Rails.env.production?
     match '/emulator(/*path)', :controller => 'emulator', :action => 'index'
   end
 

--- a/lib/mxit-rails.rb
+++ b/lib/mxit-rails.rb
@@ -1,6 +1,5 @@
 require "mxit_rails/railtie"
 require "mxit_rails/exception"
-require "mxit_rails/redirect_exception"
 require "mxit_rails/descriptor"
 require "mxit_rails/engine"
 require "mxit_rails/styles"
@@ -15,6 +14,3 @@ require "mxit_rails/mxit_api/api_client"
 require "mxit_rails/mxit_api/auth_token"
 require "mxit_rails/mxit_api/mxit_api_exception"
 require "mxit_rails/mxit_api/request_exception"
-
-module MxitRails::MXitApi
-end

--- a/lib/mxit_rails/descriptor.rb
+++ b/lib/mxit_rails/descriptor.rb
@@ -1,17 +1,5 @@
 module MxitRails
   class Descriptor
-    def self.descr_accessor variable
-      # Custom accessor macro that will look in a parent descriptor if a value isn't found (i.e. is nil)
-      attr_writer variable
-      define_method "#{variable}" do
-        value = instance_variable_get("@#{variable}")
-        if value.nil? && !parent_descriptor.nil?
-          value = parent_descriptor.send("#{variable}")
-        end
-        value
-      end
-    end
-
     attr_accessor :parent_descriptor
 
     attr_accessor :name
@@ -26,6 +14,10 @@ module MxitRails
     attr_accessor :select
     attr_accessor :select_label
     attr_accessor :select_options
+    attr_accessor :selected
+    attr_accessor :multi_select
+    attr_accessor :multi_select_next
+    attr_accessor :numbered_list
 
     attr_accessor :has_table
 
@@ -38,10 +30,6 @@ module MxitRails
       @action = action.to_sym
       @validations = []
       @steps = []
-    end
-
-    def url
-      MxitRails::Router.url "#{name}/#{action}"
     end
 
     def form?

--- a/lib/mxit_rails/page.rb
+++ b/lib/mxit_rails/page.rb
@@ -78,13 +78,14 @@ module MxitRails
 
     def clean_session
       # Drop all mxit items from session if the page doesn't match the current one
-      if (session[:_mxit_rails_page] != "#{controller_name}##{action_name}") || (params[:_mxit_reset])
+      page_identifier = request.path.sub(/^\/emulator/, '')
+      if (session[:_mxit_rails_page] != page_identifier) || (params[:_mxit_reset])
         session.each do |key, value|
           if key.to_s.match(/_mxit_rails_/)
             session[key] = nil
           end
         end
-        session[:_mxit_rails_page] = "#{controller_name}##{action_name}"
+        session[:_mxit_rails_page] = page_identifier
         params[:first_visit] = true
       else 
         params[:first_visit] = false

--- a/lib/mxit_rails/redirect_exception.rb
+++ b/lib/mxit_rails/redirect_exception.rb
@@ -1,5 +1,0 @@
-module MxitRails
-  class RedirectException < MxitRails::Exception
-    attr_accessor :route
-  end
-end

--- a/lib/mxit_rails/version.rb
+++ b/lib/mxit_rails/version.rb
@@ -1,3 +1,3 @@
 module MxitRails
-  VERSION = "0.2.9"
+  VERSION = "0.3.0"
 end

--- a/test/dummy/app/controllers/welcome_controller.rb
+++ b/test/dummy/app/controllers/welcome_controller.rb
@@ -25,6 +25,24 @@ class WelcomeController < ApplicationController
     end
   end
 
+  def single
+    select :select, 'Select an option', {'A' => 'Option A', 'B' => 'Option B', 'C' => 'Option C'}, selected: 'B', numbered_list: true
+
+    submit do
+      logger.info "Value: #{params[:select]}"
+      redirect_to '/index/success' and return
+    end
+  end
+
+  def multi
+    multi_select :select, 'Select all that apply', {'A' => 'Option A', 'B' => 'Option B', 'C' => 'Option C'}, selected: ['B', 'C'], numbered_list: true
+
+    submit do
+      logger.info "Value: #{params[:select]}"
+      redirect_to '/index/success' and return
+    end
+  end
+
   def easter_egg
   end
 

--- a/test/dummy/app/views/index/index.html.erb
+++ b/test/dummy/app/views/index/index.html.erb
@@ -11,6 +11,8 @@ This is the root of the dummy app...<br />
 <% end %>
 <br />
 
-<%= mxit_link '/welcome', 'Single-page form' %><br />
-<%= mxit_link '/form', 'Multi-step form' %><br />
-<%= mxit_link '/index', 'An extra link' %><br />
+<%= link_to 'Single-page form', '/welcome' %><br />
+<%= link_to 'Single select', '/welcome/single' %><br />
+<%= link_to 'Multi select', '/welcome/multi' %><br />
+<%= link_to 'Multi-step form', '/form' %><br />
+<%= link_to 'An extra link', '/index' %><br />

--- a/test/dummy/app/views/index/success.html.erb
+++ b/test/dummy/app/views/index/success.html.erb
@@ -2,6 +2,6 @@
 <b>Success!</b>
 
 <%= mxit_table_row %>
-<%= mxit_nav_link '/', 'Done' %>
+<%= link_to 'Done', '/' %><br /><br />
 
 Your information was successfully received.<br />

--- a/test/dummy/app/views/welcome/multi.html.erb
+++ b/test/dummy/app/views/welcome/multi.html.erb
@@ -1,0 +1,6 @@
+<%= mxit_table_row :title %>
+<b>Multi Select</b>
+
+<%= mxit_table_row %>
+<%= link_to 'Back', '/' %>
+

--- a/test/dummy/app/views/welcome/single.html.erb
+++ b/test/dummy/app/views/welcome/single.html.erb
@@ -1,0 +1,6 @@
+<%= mxit_table_row :title %>
+<b>Single Select</b>
+
+<%= mxit_table_row %>
+<%= link_to 'Back', '/' %>
+


### PR DESCRIPTION
# Changes
- Added `multi_select` input (analogous to `select` input)
- Labels on inputs (and selects) can be falsey, in which case they will be ignored
- An optional `selected` named parameter can be sent to `select` and `multi_select` to set default selected options
- An optional `numbered_list` named parameter (`true` or `false`) added to `select` and `multi_select` to format things as a numbered list. Useful for lists where the options are longer
- Enabled emulator in all non-production environments (previously only worked in development)
- Removed some deprecated methods from `MxitRails::Descriptor` class
- Fix to when submit blocks get executed, particularly for single step forms (i.e. those without the `form` command)
## Breaking Changes
- removed `mxit_link` and `mxit_nav_link` methods
- removed `redirect!` method
