### PR TITLE
Striping white space from the numeric values

### DIFF
--- a/lib/mxit_rails/validations.rb
+++ b/lib/mxit_rails/validations.rb
@@ -6,6 +6,7 @@ module MxitRails
     end
 
     def self.numeric? input
+      input.gsub! /\s*/, ''
       return !input.blank? && input.match(/^[0-9]+$/)
     end
 


### PR DESCRIPTION
From users input we have discovered they format phone numbers and numbers like " 072 123 456" this  should fix those issues with out effecting any things.
